### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,9 +9,9 @@ body:
 
         Before submitting a bug report, please make sure you've done the following:
         
-        - [ ] I have installed the [latest version of Storage Explorer](https://github.com/Microsoft/AzureStorageExplorer/releases/latest).
-        - [ ] I have checked existing resources, including the [troubleshooting guide](https://docs.microsoft.com/azure/storage/common/storage-explorer-troubleshooting) and the [release notes](https://github.com/microsoft/AzureStorageExplorer/releases).
-        - [ ] I have searched for [similar issues](https://github.com/Microsoft/AzureStorageExplorer/issues).
+          - [ ] I have installed the [latest version of Storage Explorer](https://github.com/Microsoft/AzureStorageExplorer/releases/latest).
+          - [ ] I have checked existing resources, including the [troubleshooting guide](https://docs.microsoft.com/azure/storage/common/storage-explorer-troubleshooting) and the [release notes](https://github.com/microsoft/AzureStorageExplorer/releases).
+          - [ ] I have searched for [similar issues](https://github.com/Microsoft/AzureStorageExplorer/issues).
         
         ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,22 +2,18 @@ name: Report a Bug
 description: Something not working as expected? Create an issue to help us improve.
 type: "Bug"
 body:
-  - type: checkboxes
-    id: pre-flight
-    attributes:
-      label: Preflight Checklist
-      description: "Before submitting a bug report, please make sure you've done the following:"
-      options:
-        - label: I have installed the [latest version of Storage Explorer](https://github.com/Microsoft/AzureStorageExplorer/releases/latest).
-          required: true
-        - label: I have checked existing resources, including the [troubleshooting guide](https://docs.microsoft.com/azure/storage/common/storage-explorer-troubleshooting) and the [release notes](https://github.com/microsoft/AzureStorageExplorer/releases).
-          required: true
-        - label: I have searched for [similar issues](https://github.com/Microsoft/AzureStorageExplorer/issues).
-          required: true
-
   - type: markdown
     attributes:
-      value: ---
+      value: |
+        ## Preflight Checklist
+
+        Before submitting a bug report, please make sure you've done the following:
+        
+        - [ ] I have installed the [latest version of Storage Explorer](https://github.com/Microsoft/AzureStorageExplorer/releases/latest).
+        - [ ] I have checked existing resources, including the [troubleshooting guide](https://docs.microsoft.com/azure/storage/common/storage-explorer-troubleshooting) and the [release notes](https://github.com/microsoft/AzureStorageExplorer/releases).
+        - [ ] I have searched for [similar issues](https://github.com/Microsoft/AzureStorageExplorer/issues).
+        
+        ---
 
   - type: input
     id: app-version
@@ -41,7 +37,6 @@ body:
       label: Architecture
       description: Open the About dialog in Storage Explorer to find this.
       options:
-        - i86
         - x64
         - arm64
     validations:
@@ -69,12 +64,12 @@ body:
         - Linux (snap)
     validations:
       required: true
-
+      
   - type: input
     id: os-version
     attributes:
       label: OS Version
-      placeholder: Windows 10; macOS Big Sur; Ubuntu 20.04
+      placeholder: Windows 11; macOS Sequioa 15.3.1; Ubuntu 22.04
 
   - type: markdown
     attributes:
@@ -85,6 +80,8 @@ body:
     attributes:
       label: Bug Description
       description: Provide a clear, concise description of the bug.
+      placeholder: |
+        Describe the bug you're seeing.
     validations:
       required: true
 
@@ -104,6 +101,8 @@ body:
     attributes:
       label: Actual Experience
       description: Provide a clear, concise description of what actually happens. If applicable, add screenshots to help explain what happened.
+      placeholder: |
+        What actually happens when I follow the steps to reproduce?
     validations:
       required: true
 
@@ -112,9 +111,14 @@ body:
     attributes:
       label: Expected Experience
       description: Provide a clear, concise description of what you expected to happen. If applicable, add screenshots to help explain what you expected.
+      placeholder: |
+        What should happen when I follow the steps to reproduce?
 
   - type: textarea
     id: context
     attributes:
       label: Additional Context
       description: Add any other details, such as error messages, unusual system configurations, network restrictions, etc.
+      placeholder: |
+        Error messages, proxy configurations, system permissions, etc.
+        

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Preflight Checklist
+        ### Preflight Checklist
 
         Before submitting a bug report, please make sure you've done the following:
         

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,8 +69,7 @@ body:
     id: os-version
     attributes:
       label: OS Version
-      placeholder: Windows 11; macOS Sequioa 15.3.1; Ubuntu 22.04
-
+      placeholder: Windows 11; macOS Sequoia 15.3.1; Ubuntu 22.04
   - type: markdown
     attributes:
       value: ---

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,9 +9,9 @@ body:
 
         Before submitting a bug report, please make sure you've done the following:
         
-          - [ ] I have installed the [latest version of Storage Explorer](https://github.com/Microsoft/AzureStorageExplorer/releases/latest).
-          - [ ] I have checked existing resources, including the [troubleshooting guide](https://docs.microsoft.com/azure/storage/common/storage-explorer-troubleshooting) and the [release notes](https://github.com/microsoft/AzureStorageExplorer/releases).
-          - [ ] I have searched for [similar issues](https://github.com/Microsoft/AzureStorageExplorer/issues).
+        - [ ] I have installed the [latest version of Storage Explorer](https://github.com/Microsoft/AzureStorageExplorer/releases/latest).
+        - [ ] I have checked existing resources, including the [troubleshooting guide](https://docs.microsoft.com/azure/storage/common/storage-explorer-troubleshooting) and the [release notes](https://github.com/microsoft/AzureStorageExplorer/releases).
+        - [ ] I have searched for [similar issues](https://github.com/Microsoft/AzureStorageExplorer/issues).
         
         ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,8 +1,6 @@
 name: Request a Feature
 description: Have an idea that would make Storage Explorer better? Let us know!
 type: "Feature"
-labels:
-  - ":bulb: feature request"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,22 +4,18 @@ type: "Feature"
 labels:
   - ":bulb: feature request"
 body:
-  - type: checkboxes
-    id: pre-flight
-    attributes:
-      label: Preflight Checklist
-      description: "Before submitting a feature request, please make sure you've done the following:"
-      options:
-        - label: I have installed the [latest version of Storage Explorer](https://github.com/Microsoft/AzureStorageExplorer/releases/latest).
-          required: true
-        - label: I have checked existing resources, including the [troubleshooting guide](https://docs.microsoft.com/azure/storage/common/storage-explorer-troubleshooting) and the [release notes](https://github.com/microsoft/AzureStorageExplorer/releases).
-          required: true
-        - label: I have searched for [similar issues](https://github.com/Microsoft/AzureStorageExplorer/issues).
-          required: true
-
   - type: markdown
     attributes:
-      value: ---
+      value: |
+        ### Preflight Checklist
+        
+        Before submitting a feature request, please make sure you've done the following:
+        
+        - [ ] I have installed the [latest version of Storage Explorer](https://github.com/Microsoft/AzureStorageExplorer/releases/latest).
+        - [ ] I have checked existing resources, including the [troubleshooting guide](https://docs.microsoft.com/azure/storage/common/storage-explorer-troubleshooting) and the [release notes](https://github.com/microsoft/AzureStorageExplorer/releases).
+        - [ ] I have searched for [similar issues](https://github.com/Microsoft/AzureStorageExplorer/issues).
+        
+        ---
 
   - type: input
     id: goal
@@ -58,3 +54,6 @@ body:
     attributes:
       label: Additional Context
       description: Add any other context or screenshots that can help us understand your feature request better.
+      placeholder: |
+        Often my work involves...
+        I need this for...


### PR DESCRIPTION
Our issue templates required users checking several "preflight checklist" checkboxes. Requiring these fields was an attempt to encourage users to follow these instructions before filing issues. However, they add unecessary clutter to the issues that are formed, and a lot of users either don't find what they're looking for or ignore the information anyway. Convering the information to Markdown instead of as inputs is more convenient for users and for us.