### PR TITLE
Add issue manager agent with stale issue cleanup skill

### DIFF
--- a/.github/agents/issue-manager.agent.md
+++ b/.github/agents/issue-manager.agent.md
@@ -25,7 +25,7 @@ The members of the `microsoft/azure-storage-explorer` GitHub team can be
 fetched with:
 
 ```
-gh api /orgs/microsoft/teams/azure-storage-explorer/members --jq '.[].login'
+gh api --paginate /orgs/microsoft/teams/azure-storage-explorer/members --jq '.[].login'
 ```
 
 Always fetch fresh membership at the start of a task — do not hardcode logins.

--- a/.github/skills/stale-issue-cleanup/SKILL.md
+++ b/.github/skills/stale-issue-cleanup/SKILL.md
@@ -31,7 +31,7 @@ An issue is stale when ALL of the following are true:
 Run this command to get the list of Storage Explorer team member logins:
 
 ```
-gh api /orgs/microsoft/teams/azure-storage-explorer/members --jq '.[].login'
+gh api --paginate /orgs/microsoft/teams/azure-storage-explorer/members --jq '.[].login'
 ```
 
 Store these logins for comparison throughout the process.
@@ -50,7 +50,7 @@ gh api graphql -f query='
         title
         updatedAt
         issueType { name }
-        labels(first: 10) {
+        labels(first: 50) {
           nodes { name }
         }
         comments(last: 1) {

--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -1,19 +1,21 @@
 name: Stale Issue Cleanup
 
 # Authentication:
-#   This workflow requires a token with issues:write and read:org scopes.
+#   This workflow requires a token with the following scopes:
+#     - issues:write (to comment on and close issues)
+#     - read:org (to read team membership)
+#     - read:project and project (to update the Resolution project field)
 #   For experimentation, use a PAT stored as STALE_ISSUES_TOKEN repo secret.
 #   For production, replace with a GitHub App token to avoid manual renewal:
 #     - Register one "Storage Explorer Automation" GitHub App in the microsoft org
-#     - Grant it issues:write and members:read permissions
+#     - Grant it issues:write, members:read, and projects:write permissions
 #     - Install it on this repo (and any other repos your agents need)
 #     - Use actions/create-github-app-token to generate tokens at runtime
 #     - One app can serve all agent workflows
 
 on:
   schedule:
-    # Every other Monday at 9:00 AM UTC (biweekly)
-    - cron: '0 9 1,15 * *'
+    - cron: "0 9 1,15 * *" # Twice monthly
   workflow_dispatch: # Allow manual triggers
 
 permissions:
@@ -39,7 +41,6 @@ jobs:
           agency copilot \
             --agent issue-manager \
             --prompt "Find and close stale bug issues." \
-            --allow-all-tools \
             --share stale-cleanup-log.md
 
       - name: Upload session log


### PR DESCRIPTION
Adds an agent for managing issues and a skill for handling issues that have not gotten responses from the community for some time. Also adds a workflow for running the agent periodically.