### PR TITLE
Fix issues with issue management workflow

### DIFF
--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run stale issue cleanup agent
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_TOKEN }}
-          STALE_ISSUES_TOKEN: ${{ secrets.STALE_ISSUES_TOKEN }}
+          GH_TOKEN: ${{ secrets.STALE_ISSUES_TOKEN }}
         run: |
           copilot \
             --agent issue-manager \


### PR DESCRIPTION
* Agency is an internal tool that a GitHub Action cannot access, so we switch to using GitHub Copilot CLI directly.
* For various reasons, the workflow requires two different tokens, one to authorize org and repo access, another to authorize Copilot.