### PR TITLE
Prepare versions file for 1.42.0

### DIFF
--- a/version/version.json
+++ b/version/version.json
@@ -38,6 +38,38 @@
       }
     },
     {
+      "displayName": "1.42.0",
+      "version": 113,
+      "updateGroups": [
+        {
+          "name": "default",
+          "percentage": 0
+        }
+      ],
+      "cleanInstall": true,
+      "releaseNotesUrl": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.42.0/ReleaseNotes.md",
+      "releaseNotesUrls": {
+        "markdown": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.42.0/ReleaseNotes.md"
+      },
+      "downloadInfos": {
+        "windows64": {
+          "sha256Checksum": "0af583a9d09d02cf06e1bd3e2227733c9acde2ccd0ff9c41d4769b3d24889284"
+        },
+        "windowsArm64": {
+          "sha256Checksum": "e32f1850da7683ea800cb56cb5501a0bc68d4a9c502b843144270779610b8f4d"
+        },
+        "mac": {
+          "sha256Checksum": "7a3d2d9db72402cb2f5b495428b7fe7cb2fd397026f7fd2651f05c85b828f231"
+        },
+        "macArm64": {
+          "sha256Checksum": "0ca69783783391eec7aff2496183af78aa2e52854d6a1547b286dd60be4f7a13"
+        },
+        "linux": {
+          "sha256Checksum": "889fcfbc59ca11b3797f1c055a3c6cf326e3b100af4b27ec4b1e7b8fa945b8aa"
+        }
+      }
+    },
+    {
       "displayName": "1.41.1",
       "version": 112,
       "updateGroups": [
@@ -442,12 +474,20 @@
   ],
   "deprecations": [
     {
+      "version": 105,
+      "displayName": "1.38.0",
+      "deprecationDate": "04/11/2026",
+      "messageLevel": "info",
+      "includePreviousVersionsMessage": false,
+      "alwaysShow": false
+    },
+    {
       "version": 104,
       "displayName": "1.37.0",
       "deprecationDate": "01/06/2026",
       "messageLevel": "info",
       "includePreviousVersionsMessage": false,
-      "alwaysShow": false
+      "alwaysShow": true
     },
     {
       "version": 103,
@@ -455,7 +495,7 @@
       "deprecationDate": "10/29/2025",
       "messageLevel": "info",
       "includePreviousVersionsMessage": false,
-      "alwaysShow": false
+      "alwaysShow": true
     },
     {
       "version": 101,
@@ -463,7 +503,7 @@
       "deprecationDate": "10/14/2025",
       "messageLevel": "info",
       "includePreviousVersionsMessage": false,
-      "alwaysShow": false
+      "alwaysShow": true
     },
     {
       "version": 100,
@@ -471,7 +511,7 @@
       "deprecationDate": "09/19/2025",
       "messageLevel": "info",
       "includePreviousVersionsMessage": false,
-      "alwaysShow": false
+      "alwaysShow": true
     },
     {
       "version": 99,


### PR DESCRIPTION
Adds v1.42.0 entry to version.json (version 113, 0% rollout) with SHA-256 checksums verified against SBOM manifests.

Also adds v1.38.0 to the deprecations list (deprecation date 04/11/2026) and flips `alwaysShow` to `true` for versions whose deprecation date has already passed (v1.35.0–v1.37.0).