### PR TITLE
Roll out 1.43.0 to 100%

### DIFF
--- a/version/version.json
+++ b/version/version.json
@@ -43,7 +43,7 @@
       "updateGroups": [
         {
           "name": "default",
-          "percentage": 50
+          "percentage": 100
         }
       ],
       "cleanInstall": true,


### PR DESCRIPTION
Increase the 1.43.0 rollout percentage from 50% to 100% after stable monitoring.
