### PR TITLE
Roll out 1.44.0 to 50%

### DIFF
--- a/version/version.json
+++ b/version/version.json
@@ -43,7 +43,7 @@
       "updateGroups": [
         {
           "name": "default",
-          "percentage": 0
+          "percentage": 50
         }
       ],
       "cleanInstall": true,


### PR DESCRIPTION
Increases the default-group rollout percentage for 1.44.0 from 0% to 50%.