### PR TITLE
Roll out 1.45.0 to 50%

### DIFF
--- a/version/version.json
+++ b/version/version.json
@@ -43,7 +43,7 @@
       "updateGroups": [
         {
           "name": "default",
-          "percentage": 0
+          "percentage": 50
         }
       ],
       "cleanInstall": true,


### PR DESCRIPTION
## Problem

1.45.0 shipped at 0% rollout so no clients are offered the update yet. Initial monitoring of the release looks healthy.

## Fix

Advance the 1.45.0 default update group to 50%, the first phased-rollout increment. `cleanInstall` stays `true` during the rollout phase.

## Related work items

[#9146](https://github.com/microsoft/AzureStorageExplorer/issues/9146)
