### PR TITLE
Roll out 1.45.0 to 100%

### DIFF
--- a/version/version.json
+++ b/version/version.json
@@ -43,7 +43,7 @@
       "updateGroups": [
         {
           "name": "default",
-          "percentage": 0
+          "percentage": 50
         }
       ],
       "cleanInstall": true,

--- a/version/version.json
+++ b/version/version.json
@@ -43,10 +43,10 @@
       "updateGroups": [
         {
           "name": "default",
-          "percentage": 50
+          "percentage": 100
         }
       ],
-      "cleanInstall": true,
+      "cleanInstall": false,
       "releaseNotesUrl": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.45.0/ReleaseNotes.md",
       "releaseNotesUrls": {
         "markdown": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.45.0/ReleaseNotes.md"

--- a/version/version.json
+++ b/version/version.json
@@ -46,7 +46,7 @@
           "percentage": 100
         }
       ],
-      "cleanInstall": false,
+      "cleanInstall": true,
       "releaseNotesUrl": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.45.0/ReleaseNotes.md",
       "releaseNotesUrls": {
         "markdown": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.45.0/ReleaseNotes.md"


### PR DESCRIPTION
## Problem

Completes the 1.45.0 phased rollout. Assumes the 50% increment has been merged and monitored with no issues.

## Fix

Advance the 1.45.0 default update group to 100% (full rollout) and set `cleanInstall` to `false`, since a clean install is only required during the initial rollout phase.

## Dependencies

Stacked on the 50% rollout PR (#9147). Once #9147 merges, this PR's diff reduces to the 50% to 100% change. Merge after #9147.
